### PR TITLE
Fixed invalid folder name in change directory command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A desktop application to help you cheat on everything.
 1. Clone the repository:
 ```bash
 git clone [repository-url]
-cd interview-coder
+cd free-cluely
 ```
 
 2. Install dependencies:


### PR DESCRIPTION
After cloning the repo there is a command `cd interview-coder` which is invalid. As the repo name is `free-cluely`. Changed the command to exact folder so that contributors don't get confused