### PR TITLE
Make overlay window draggable via CSS drag region

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -154,6 +154,18 @@ const App: React.FC = () => {
 
   return (
     <div ref={containerRef} className="min-h-0">
+      <div
+        style={{
+          position: "fixed",
+          top: 0,
+          left: 0,
+          width: "100%",
+          height: "40px",
+          zIndex: 9999,
+          cursor: "grab"
+        }}
+        className="draggable-area"
+      ></div>
       <QueryClientProvider client={queryClient}>
         <ToastProvider>
           {view === "queue" ? (

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.draggable-area {
+  -webkit-app-region: drag;
+}


### PR DESCRIPTION
This PR adds support for dragging the application window by introducing a draggable region using Electron’s -webkit-app-region: drag:

src/App.tsx: Injected a <div className="draggable-area"> at the top of the app layout to serve as the drag handle.

src/index.css: Added the .draggable-area class with -webkit-app-region: drag to enable native window dragging in frameless Electron mode.

This enables users on macOS, Windows, and Linux to reposition the overlay window using a clean, minimal top strip